### PR TITLE
op3: Enable WiFi channel bonding for 2.4GHz mode

### DIFF
--- a/wifi/WCNSS_qcom_cfg.ini
+++ b/wifi/WCNSS_qcom_cfg.ini
@@ -328,7 +328,7 @@ gAPChannelSelectOperatingBand=0
 
 #Channel Bonding
 gChannelBondingMode5GHz=1
-gChannelBondingMode24GHz=0
+gChannelBondingMode24GHz=1
 
 
 #Enable Keep alive with non-zero period value


### PR DESCRIPTION
This should enable WiFi channel bonding for 2.4GHz mode allowing to use 40 MHz channels too, thereby doubling the maximum link speed to 150 Mbps. It would be a great help to people whose WiFi speeds were being limited due to disabled channel bonding support.